### PR TITLE
Feat 18: 라이더 배달 배차, 픽업, 배달완료 서비스 구현

### DIFF
--- a/src/main/java/com/wow/delivery/controller/OrderController.java
+++ b/src/main/java/com/wow/delivery/controller/OrderController.java
@@ -50,12 +50,14 @@ public class OrderController {
     }
 
     @PostMapping("/pickup")
-    public void pickupOrder(@RequestBody @Valid OrderDeliveryDTO orderDeliveryDTO) {
+    public ResponseEntity<HttpStatus> pickupOrder(@RequestBody @Valid OrderDeliveryDTO orderDeliveryDTO) {
         orderService.pickupOrder(orderDeliveryDTO);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @PostMapping("/delivery-complete")
-    public void deliveredOrder(@RequestBody @Valid OrderDeliveryDTO orderDeliveryDTO) {
+    public ResponseEntity<HttpStatus> deliveredOrder(@RequestBody @Valid OrderDeliveryDTO orderDeliveryDTO) {
         orderService.deliveredOrder(orderDeliveryDTO);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/wow/delivery/controller/OrderController.java
+++ b/src/main/java/com/wow/delivery/controller/OrderController.java
@@ -1,15 +1,14 @@
 package com.wow.delivery.controller;
 
-import com.wow.delivery.dto.order.OrderAcceptDTO;
-import com.wow.delivery.dto.order.OrderCancelDTO;
-import com.wow.delivery.dto.order.OrderCreateDTO;
-import com.wow.delivery.dto.order.OrderResponse;
+import com.wow.delivery.dto.order.*;
 import com.wow.delivery.service.order.OrderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -35,7 +34,7 @@ public class OrderController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
-    @PostMapping("/accecpt")
+    @PostMapping("/accept")
     public void acceptOrder(@RequestBody @Valid OrderAcceptDTO orderAcceptDTO) {
         orderService.acceptOrder(orderAcceptDTO);
     }
@@ -43,5 +42,20 @@ public class OrderController {
     @PostMapping("/reject")
     public void rejectOrder(@RequestBody @Valid OrderAcceptDTO orderAcceptDTO) {
         orderService.rejectOrder(orderAcceptDTO);
+    }
+
+    @GetMapping("/nearby")
+    public ResponseEntity<List<OrderDeliveryResponse>> getOrders(@RequestBody @Valid NearbyOrderRequestDTO requestDTO) {
+        return ResponseEntity.ok(orderService.getNearbyOrder(requestDTO));
+    }
+
+    @PostMapping("/pickup")
+    public void pickupOrder(@RequestBody @Valid OrderDeliveryDTO orderDeliveryDTO) {
+        orderService.pickupOrder(orderDeliveryDTO);
+    }
+
+    @PostMapping("/delivery-complete")
+    public void deliveredOrder(@RequestBody @Valid OrderDeliveryDTO orderDeliveryDTO) {
+        orderService.deliveredOrder(orderDeliveryDTO);
     }
 }

--- a/src/main/java/com/wow/delivery/dto/order/NearbyOrderRequestDTO.java
+++ b/src/main/java/com/wow/delivery/dto/order/NearbyOrderRequestDTO.java
@@ -1,0 +1,23 @@
+package com.wow.delivery.dto.order;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NearbyOrderRequestDTO {
+
+    private String riderId; // 라이더 ID
+    private String streetName; // 주소(도로명)
+    private Double latitude; // 위도
+    private Double longitude; // 경도
+
+    @Builder
+    public NearbyOrderRequestDTO(String riderId, String streetName, Double latitude, Double longitude) {
+        this.riderId = riderId;
+        this.streetName = streetName;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/src/main/java/com/wow/delivery/dto/order/OrderDeliveryDTO.java
+++ b/src/main/java/com/wow/delivery/dto/order/OrderDeliveryDTO.java
@@ -1,0 +1,23 @@
+package com.wow.delivery.dto.order;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderDeliveryDTO {
+
+    @NotNull
+    private Long orderId; // 주문 ID
+
+    @NotNull
+    private Long riderId; // 라이더 ID
+
+    @Builder
+    public OrderDeliveryDTO(Long orderId, Long riderId) {
+        this.orderId = orderId;
+        this.riderId = riderId;
+    }
+}

--- a/src/main/java/com/wow/delivery/dto/order/OrderDeliveryResponse.java
+++ b/src/main/java/com/wow/delivery/dto/order/OrderDeliveryResponse.java
@@ -1,0 +1,30 @@
+package com.wow.delivery.dto.order;
+
+import com.wow.delivery.entity.common.Address;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderDeliveryResponse {
+
+    private Long orderId; // 주문 Id
+
+    private Long shopId; // 가게 ID
+
+    private String shopName; // 가게 명
+
+    private Address shopAddress; // 가게 주소
+
+    private Address destination; // 배달 수령지
+
+    @Builder
+    public OrderDeliveryResponse(Long orderId, Long shopId, String shopName, Address shopAddress, Address destination) {
+        this.orderId = orderId;
+        this.shopId = shopId;
+        this.shopName = shopName;
+        this.shopAddress = shopAddress;
+        this.destination = destination;
+    }
+}

--- a/src/main/java/com/wow/delivery/dto/shop/NearbyShopRequestDTO.java
+++ b/src/main/java/com/wow/delivery/dto/shop/NearbyShopRequestDTO.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class NearbyShopRequestDTO {
 
-    private Long userId; // 가게사장 식별번호
+    private Long userId; // 유저 ID
     private String state; // 주소(도)
     private String city; // 주소(시)
     private String district; // 주소(구,군)

--- a/src/main/java/com/wow/delivery/entity/RiderEntity.java
+++ b/src/main/java/com/wow/delivery/entity/RiderEntity.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(uniqueConstraints = { @UniqueConstraint(name = "email_phoneNumber_unique", columnNames = { "email", "phone_number" }) })
-public class Rider extends BaseEntity {
+public class RiderEntity extends BaseEntity {
 
     @Column(name = "email", columnDefinition = "VARCHAR(30)", nullable = false)
     private String email;
@@ -27,7 +27,7 @@ public class Rider extends BaseEntity {
     private String phoneNumber;
 
     @Builder
-    public Rider(String email, String password, String salt, String phoneNumber) {
+    public RiderEntity(String email, String password, String salt, String phoneNumber) {
         this.email = email;
         this.password = password;
         this.salt = salt;

--- a/src/main/java/com/wow/delivery/entity/order/OrderEntity.java
+++ b/src/main/java/com/wow/delivery/entity/order/OrderEntity.java
@@ -21,7 +21,7 @@ public class OrderEntity extends BaseEntity {
     @Comment(value = "가게 ID")
     private Long shopId;
 
-    @Comment(value = "라이더 ID")
+    @Comment(value = "담당 라이더 ID")
     private Long riderId;
 
     @Comment(value = "거래 ID")
@@ -29,7 +29,8 @@ public class OrderEntity extends BaseEntity {
 
     @Comment(value = "배달 받을 주소")
     @Embedded
-    private Address address;
+    @Column(nullable = false)
+    private Address destination;
 
     @Comment(value = "주문 번호")
     @Column(name = "order_number", columnDefinition = "VARCHAR(10)", nullable = false)
@@ -61,8 +62,8 @@ public class OrderEntity extends BaseEntity {
     private Long couponId;
 
     @Builder
-    public OrderEntity(Address address, Long userId, Long shopId, Long paymentId, String orderRequest, Long orderPrice, Long deliveryFee, Long totalPaymentAmount, Long couponId) {
-        this.address = address;
+    public OrderEntity(Address destination, Long userId, Long shopId, Long paymentId, String orderRequest, Long orderPrice, Long deliveryFee, Long totalPaymentAmount, Long couponId) {
+        this.destination = destination;
         this.userId = userId;
         this.shopId = shopId;
         this.paymentId = paymentId;
@@ -85,5 +86,9 @@ public class OrderEntity extends BaseEntity {
 
     public boolean isCancelAbleStatus() {
         return this.getOrderStatus().equals(OrderStatus.CONFIRMING);
+    }
+
+    public void assignRider(Long riderId) {
+        this.riderId = riderId;
     }
 }

--- a/src/main/java/com/wow/delivery/entity/order/OrderEntity.java
+++ b/src/main/java/com/wow/delivery/entity/order/OrderEntity.java
@@ -29,7 +29,6 @@ public class OrderEntity extends BaseEntity {
 
     @Comment(value = "배달 받을 주소")
     @Embedded
-    @Column(nullable = false)
     private Address destination;
 
     @Comment(value = "주문 번호")
@@ -90,5 +89,13 @@ public class OrderEntity extends BaseEntity {
 
     public void assignRider(Long riderId) {
         this.riderId = riderId;
+    }
+
+    public boolean isSameRider(Long riderId) {
+        return this.riderId.equals(riderId);
+    }
+
+    public boolean isDelivering() {
+        return this.orderStatus == OrderStatus.DELIVERING;
     }
 }

--- a/src/main/java/com/wow/delivery/error/ErrorCode.java
+++ b/src/main/java/com/wow/delivery/error/ErrorCode.java
@@ -20,6 +20,7 @@ public enum ErrorCode {
     ORDER_DATA_NOT_FOUND("주문 데이터를 찾을 수 없습니다."),
     ORDER_DETAILS_NOT_FOUND("상세 주문 데이터를 찾을 수 없습니다."),
     COUPON_DATA_NOT_FOUND("쿠폰 데이터를 찾을 수 없습니다."),
+    RIDER_DATA_NOT_FOUND("라이더 데이터를 찾을 수 없습니다."),
 
     // Parameter
     INVALID_PARAMETER("유효하지 않은 입력 값입니다."),

--- a/src/main/java/com/wow/delivery/error/ErrorCode.java
+++ b/src/main/java/com/wow/delivery/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
     // EXPIRE
     EXPIRE_DATA("만료된 데이터 입니다.");
 
+
     private final String message;
 
     ErrorCode(String message) {

--- a/src/main/java/com/wow/delivery/kafka/KafkaTopics.java
+++ b/src/main/java/com/wow/delivery/kafka/KafkaTopics.java
@@ -7,4 +7,6 @@ public class KafkaTopics {
     public static final String SUCCESS_COUPON = "success.coupon";
     public static final String ACCEPT_ORDER = "accept.order";
     public static final String REJECT_ORDER = "reject.order";
+    public static final String PICKUP_ORDER = "pickup.order";
+    public static final String DELIVERED_ORDER = "delivered.order";
 }

--- a/src/main/java/com/wow/delivery/kafka/consumer/OrderConsumer.java
+++ b/src/main/java/com/wow/delivery/kafka/consumer/OrderConsumer.java
@@ -3,8 +3,10 @@ package com.wow.delivery.kafka.consumer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wow.delivery.dto.order.OrderDeliveryDTO;
 import com.wow.delivery.dto.order.OrderResponse;
 import com.wow.delivery.kafka.KafkaTopics;
+import com.wow.delivery.service.NotificationService;
 import com.wow.delivery.service.order.OrderService;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -17,12 +19,33 @@ public class OrderConsumer {
 
     private final ObjectMapper objectMapper;
     private final OrderService orderService;
+    private final NotificationService notificationService;
 
     @KafkaListener(topics = {KafkaTopics.FAIL_COUPON}, groupId = "kafkaTest")
     public void receiveMessage(ConsumerRecord<String, String> record) {
         try {
             OrderResponse orderResponse = objectMapper.readValue(record.value(), new TypeReference<>() {});
             orderService.cancelOrder(orderResponse);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @KafkaListener(topics = {KafkaTopics.PICKUP_ORDER}, groupId = "kafkaTest")
+    public void pickupOrderMessage(ConsumerRecord<String, String> record) {
+        try {
+            OrderDeliveryDTO orderDeliveryDTO = objectMapper.readValue(record.value(), new TypeReference<>() {});
+            notificationService.sendKakaoOrderPickupNotification(orderDeliveryDTO.getOrderId());
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @KafkaListener(topics = {KafkaTopics.DELIVERED_ORDER}, groupId = "kafkaTest")
+    public void deliveredOrderMessage(ConsumerRecord<String, String> record) {
+        try {
+            OrderDeliveryDTO orderDeliveryDTO = objectMapper.readValue(record.value(), new TypeReference<>() {});
+            notificationService.sendKakaoOrderPickupNotification(orderDeliveryDTO.getOrderId());
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/com/wow/delivery/repository/AppliedRiderRepository.java
+++ b/src/main/java/com/wow/delivery/repository/AppliedRiderRepository.java
@@ -10,8 +10,8 @@ public class AppliedRiderRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public Long addRider(Long orderId, Long riderId) {
+    public Long addRider(Long orderId) {
         return redisTemplate.opsForSet()
-            .add(orderId.toString(), riderId.toString());
+            .add(orderId.toString(), "assingRider");
     }
 }

--- a/src/main/java/com/wow/delivery/repository/AppliedRiderRepository.java
+++ b/src/main/java/com/wow/delivery/repository/AppliedRiderRepository.java
@@ -1,0 +1,17 @@
+package com.wow.delivery.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class AppliedRiderRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public Long addRider(Long orderId, Long riderId) {
+        return redisTemplate.opsForSet()
+            .add(orderId.toString(), riderId.toString());
+    }
+}

--- a/src/main/java/com/wow/delivery/repository/MenuRepository.java
+++ b/src/main/java/com/wow/delivery/repository/MenuRepository.java
@@ -1,7 +1,6 @@
 package com.wow.delivery.repository;
 
 import com.wow.delivery.entity.menu.MenuEntity;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
@@ -10,12 +9,6 @@ import java.util.List;
 @Repository
 public interface MenuRepository extends CustomJpaRepository<MenuEntity, Long> {
 
-    @Query(value = """
-        SELECT m FROM MenuEntity m
-         WHERE m.shopId = :shopId
-         ORDER BY m.menuOrder ASC
-    """)
-    List<MenuEntity> findAllByShopIdOrderByOrder(@Param("shopId") Long shopId);
-
+    List<MenuEntity> findAllByShopIdOrderByMenuOrderAsc(@Param("shopId") Long shopId);
     List<MenuEntity> findByIdIn(List<Long> menuIds);
 }

--- a/src/main/java/com/wow/delivery/repository/OrderRepository.java
+++ b/src/main/java/com/wow/delivery/repository/OrderRepository.java
@@ -1,9 +1,41 @@
 package com.wow.delivery.repository;
 
+import com.wow.delivery.dto.order.OrderDeliveryResponse;
 import com.wow.delivery.entity.order.OrderEntity;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface OrderRepository extends CustomJpaRepository<OrderEntity, Long> {
     Optional<OrderEntity> findByOrderNumber(String orderNumber);
+
+    @Query("""
+    SELECT new com.wow.delivery.dto.order.OrderDeliveryResponse(
+           o.id,
+           s.id,
+           s.shopName,
+           s.address,
+           o.destination)
+      FROM OrderEntity o
+      LEFT JOIN ShopEntity s ON o.shopId = s.id
+     WHERE s.s2LevelToken.s2Level12Token IN :tokens
+       AND o.orderStatus = 'PREPARING'
+    """)
+    List<OrderDeliveryResponse> findNearbyOrderLevel12(@Param("tokens") List<String> tokens);
+
+    @Query("""
+    SELECT new com.wow.delivery.dto.order.OrderDeliveryResponse(
+           o.id,
+           s.id,
+           s.shopName,
+           s.address,
+           o.destination)
+      FROM OrderEntity o
+      LEFT JOIN ShopEntity s ON o.shopId = s.id
+     WHERE s.s2LevelToken.s2Level13Token IN :tokens
+       AND o.orderStatus = 'PREPARING'
+    """)
+    List<OrderDeliveryResponse> findNearbyOrderLevel13(@Param("tokens") List<String> tokens);
 }

--- a/src/main/java/com/wow/delivery/repository/RiderRepository.java
+++ b/src/main/java/com/wow/delivery/repository/RiderRepository.java
@@ -1,6 +1,6 @@
 package com.wow.delivery.repository;
 
-import com.wow.delivery.entity.Rider;
+import com.wow.delivery.entity.RiderEntity;
 import com.wow.delivery.error.ErrorCode;
 import com.wow.delivery.error.exception.DataNotFoundException;
 import org.springframework.stereotype.Repository;
@@ -8,14 +8,14 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface RiderRepository extends CustomJpaRepository<Rider, Long> {
+public interface RiderRepository extends CustomJpaRepository<RiderEntity, Long> {
 
     boolean existsByEmail(String email);
     boolean existsByPhoneNumber(String phoneNumber);
 
-    Optional<Rider> findRiderByEmail(String email);
+    Optional<RiderEntity> findRiderByEmail(String email);
 
-    default Rider getByEmail(String email) {
+    default RiderEntity getByEmail(String email) {
         return findRiderByEmail(email)
             .orElseThrow(() -> new DataNotFoundException(ErrorCode.DATA_NOT_FOUND, "일치하는 계정을 찾을 수 없습니다."));
     }

--- a/src/main/java/com/wow/delivery/service/MenuService.java
+++ b/src/main/java/com/wow/delivery/service/MenuService.java
@@ -47,7 +47,7 @@ public class MenuService {
     @Transactional(readOnly = true)
     public List<MenuResponse> getMenus(Long shopId) {
         ShopEntity shopEntity = shopRepository.findByIdOrThrow(shopId, ErrorCode.SHOP_DATA_NOT_FOUND, null);
-        List<MenuEntity> answer = menuRepository.findAllByShopIdOrderByMenuOrder(shopEntity.getIdOrThrow());
+        List<MenuEntity> answer = menuRepository.findAllByShopIdOrderByMenuOrderAsc(shopEntity.getIdOrThrow());
         return answer.stream()
             .map(menuEntity -> MenuResponse.builder()
                 .menuId(menuEntity.getIdOrThrow())

--- a/src/main/java/com/wow/delivery/service/NotificationService.java
+++ b/src/main/java/com/wow/delivery/service/NotificationService.java
@@ -25,4 +25,16 @@ public class NotificationService {
         // 앱으로 알림 전송
         log.info("해당 유저에게 주문 실패 카카오 알림 전송 : {} ", shopId);
     }
+
+    public void sendKakaoOrderPickupNotification(Long orderId) {
+        // 비동기로 작성
+        // 앱으로 알림 전송
+        log.info("배달 픽업 카카오 알림 전송 : {} ", orderId);
+    }
+
+    public void sendKakaoOrderDeliveredNotification(Long orderId) {
+        // 비동기로 작성
+        // 앱으로 알림 전송
+        log.info("배달 완료 카카오 알림 전송 : {} ", orderId);
+    }
 }

--- a/src/main/java/com/wow/delivery/service/RiderService.java
+++ b/src/main/java/com/wow/delivery/service/RiderService.java
@@ -4,7 +4,7 @@ import com.wow.delivery.dto.common.PasswordEncodingDTO;
 import com.wow.delivery.dto.rider.RiderSigninDTO;
 import com.wow.delivery.dto.rider.RiderSigninResponse;
 import com.wow.delivery.dto.rider.RiderSignupDTO;
-import com.wow.delivery.entity.Rider;
+import com.wow.delivery.entity.RiderEntity;
 import com.wow.delivery.error.ErrorCode;
 import com.wow.delivery.error.exception.DataNotFoundException;
 import com.wow.delivery.error.exception.InvalidParameterException;
@@ -28,7 +28,7 @@ public class RiderService {
         validDuplicateRider(riderSignupDTO);
         PasswordEncodingDTO passwordEncoder =
             PasswordEncoder.encodePassword(riderSignupDTO.getPassword());
-        Rider rider = Rider.builder()
+        RiderEntity rider = RiderEntity.builder()
             .email(riderSignupDTO.getEmail())
             .password(passwordEncoder.getEncodePassword())
             .salt(passwordEncoder.getSalt())
@@ -39,7 +39,7 @@ public class RiderService {
 
     @Transactional(readOnly = true)
     public RiderSigninResponse signin(RiderSigninDTO userSigninDTO, HttpSession session) {
-        Rider rider = riderRepository.getByEmail(userSigninDTO.getEmail());
+        RiderEntity rider = riderRepository.getByEmail(userSigninDTO.getEmail());
         if (!PasswordEncoder.matchesPassword(userSigninDTO.getPassword(), rider.getPassword(), rider.getSalt())) {
             throw new DataNotFoundException(ErrorCode.DATA_NOT_FOUND, "일치하는 계정을 찾을 수 없습니다.");
         }

--- a/src/main/java/com/wow/delivery/service/S2Service.java
+++ b/src/main/java/com/wow/delivery/service/S2Service.java
@@ -36,7 +36,7 @@ public class S2Service {
             .toList();
     }
 
-    public boolean isPopulatedArea(String state) {
-        return POPULATED_STREET_NAMES.contains(state);
+    public boolean isPopulatedStreetName(String streetName) {
+        return POPULATED_STREET_NAMES.contains(streetName);
     }
 }

--- a/src/main/java/com/wow/delivery/service/ShopService.java
+++ b/src/main/java/com/wow/delivery/service/ShopService.java
@@ -85,7 +85,7 @@ public class ShopService {
                                                     BiFunction<List<String>, T, List<ShopEntity>> populatedAreaMethod,
                                                     BiFunction<List<String>, T, List<ShopEntity>> nonPopulatedAreaMethod,
                                                     T searchParameter) {
-        if (s2Service.isPopulatedArea(requestDTO.getState())) {
+        if (s2Service.isPopulatedStreetName(requestDTO.getStreetName())) {
             List<String> tokens = s2Service.getNearbyCellIdTokens(requestDTO.getLatitude(), requestDTO.getLongitude(), 2000, 13);
             return populatedAreaMethod.apply(tokens, searchParameter);
         }

--- a/src/test/java/com/wow/delivery/service/MenuServiceTest.java
+++ b/src/test/java/com/wow/delivery/service/MenuServiceTest.java
@@ -173,7 +173,7 @@ class MenuServiceTest {
 
             given(shopRepository.findById(any()))
                 .willReturn(Optional.of(shopEntity));
-            given(menuRepository.findAllByShopIdOrderByMenuOrder(any()))
+            given(menuRepository.findAllByShopIdOrderByMenuOrderAsc(any()))
                 .willReturn(List.of(menuEntity));
 
             // when

--- a/src/test/java/com/wow/delivery/service/RiderEntityServiceTest.java
+++ b/src/test/java/com/wow/delivery/service/RiderEntityServiceTest.java
@@ -3,7 +3,7 @@ package com.wow.delivery.service;
 import com.wow.delivery.dto.common.PasswordEncodingDTO;
 import com.wow.delivery.dto.rider.RiderSigninDTO;
 import com.wow.delivery.dto.rider.RiderSignupDTO;
-import com.wow.delivery.entity.Rider;
+import com.wow.delivery.entity.RiderEntity;
 import com.wow.delivery.error.exception.DataNotFoundException;
 import com.wow.delivery.error.exception.InvalidParameterException;
 import com.wow.delivery.repository.RiderRepository;
@@ -28,7 +28,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-class RiderServiceTest {
+class RiderEntityServiceTest {
 
     @InjectMocks
     private RiderService riderService;
@@ -125,7 +125,7 @@ class RiderServiceTest {
             PasswordEncodingDTO passwordEncoder =
                 PasswordEncoder.encodePassword(signupDTO.getPassword());
 
-            Rider rider = Rider.builder()
+            RiderEntity rider = RiderEntity.builder()
                 .email(signupDTO.getEmail())
                 .password(passwordEncoder.getEncodePassword())
                 .salt(passwordEncoder.getSalt())
@@ -187,7 +187,7 @@ class RiderServiceTest {
             PasswordEncodingDTO passwordEncoder =
                 PasswordEncoder.encodePassword(password);
 
-            Rider rider = Rider.builder()
+            RiderEntity rider = RiderEntity.builder()
                 .email("seyun@gmail.com")
                 .password(passwordEncoder.getEncodePassword())
                 .salt(passwordEncoder.getSalt())


### PR DESCRIPTION
# 🔨 변경 / 추가 사항
## 라이더 배차 조회 기능
- 반경 4km 내의 주문들을 볼 수 있고 해당 주문을 클릭하여 배차받을 수 있다.
- 미리 설정해놓은 도로명은 인구 밀집지역으로 거리를 근방 2km까지 줄여서 배차받을 수 있다.
## 라이더 배차받기 기능
- 원하는 가게주문을 클릭하여 배차받을 수 있다.
- 동시성 이슈가 발생하므로 Redis를 이용하여 해결.
- kafka와 연동하여 가상의 알림을 보내도록 연동.
## 라이더 배달 완료 기능
- 배달 완료시 주문의 상태를 'DELIVERED(배달완료)' 로 변경
- - -
# 💡 고민 사항
## 동시에 여러명의 라이더가 하나의 주문을 배차신청 한다면 분명히 동시성 이슈가 발생한다.
### Redis로 해결
- 자바 synchronized 예약어는 멀티서버에서 적용도 안될뿐더러 성능이 좋지않다.
- Redis의 싱글스레드를 활용한 Redis Set을 활용하여 선착순 동시성 이슈 해결 

# 📌 질문 사항
## 동시성 이슈로 Redis Set 말고 incr를 활용해도 되는지 궁금합니다.

